### PR TITLE
Trim long image path by sha1

### DIFF
--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -2,6 +2,7 @@ package crawler
 
 import (
 	"context"
+	"crypto/sha1"
 	"errors"
 	"fmt"
 	"io"
@@ -163,6 +164,11 @@ func (c Crawler) downloadImages(ctx context.Context, entry blog.Entry, urls []st
 			return err
 		}
 		basename := path.Base(url.Path)
+
+		// convert long file name
+		if len(basename) > 127 {
+			basename = fmt.Sprintf("%X", sha1.Sum([]byte(basename)))
+		}
 
 		resp, err := downloader.Download(ctx, src)
 		if err != nil {

--- a/pkg/crawler/filter_test.go
+++ b/pkg/crawler/filter_test.go
@@ -107,12 +107,15 @@ func TestCategoryFilter(t *testing.T) {
 }
 
 func TestImagePathFilter(t *testing.T) {
+	superlongfilename := strings.Repeat("x", 1024)
 	src := `<html><head></head><body>` +
 		`<img src="https://my-cdn.example.com/2020/03/01/foobar.png"/>` +
+		`<img src="https://my-cdn.example.com/2020/03/01/` + superlongfilename + `.png"/>` +
 		`<x-img src="https://my-cdn.example.com/2020/03/01/foobar.png"></x-img>` +
 		`</body></html>`
 	result := `<html><head></head><body>` +
-		`<img src="foobar.png"/>` +
+		`<img src="foobar.png" data-original-url="https://my-cdn.example.com/2020/03/01/foobar.png"/>` +
+		`<img src="2A3F1601C5398FF43DD74490C9D55B6018789F07" data-original-url="https://my-cdn.example.com/2020/03/01/` + superlongfilename + `.png"/>` +
 		`<x-img src="https://my-cdn.example.com/2020/03/01/foobar.png"></x-img>` +
 		`</body></html>`
 


### PR DESCRIPTION
Trim file names of images with long filename.  It considers addresses length of the filename liminitation on the filesystem.  On common Unix file system, less than 256 characters is recommended.

This change suppress image file name with basename grater than 127 characters with sha1 sum.  The original URL of the image is saved on `data-original-url` attribute.

For example, image with URL`https://my-cdn.example.com/2020/03/01/foobar.png` is converted as the following `img` tag:
```html
<img
    src="foobar.png"
    data-original-url="https://my-cdn.example.com/2020/03/01/foobar.png"
/>`
```

For long URL `https://my-cdn.example.com/2020/03/01/<repeats 'x' 1,000 times>.png` :
```html
<img
    src="2A3F1601C5398FF43DD74490C9D55B6018789F07"
    data-original-url="https://my-cdn.example.com/2020/03/01/<repeats 'x' 1,000 times>.png"
/>`
```